### PR TITLE
Add post create sh to config the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,6 +26,7 @@
                 "editor.tabSize": 2,
                 "files.encoding": "utf8",
                 "terminal.integrated.scrollback": 20000,
+                "java.compile.nullAnalysis.mode": "automatic",
                 "[jsonc]": {
                     "editor.defaultFormatter": "vscode.json-language-features",
                     "editor.tabSize": 4
@@ -35,5 +36,7 @@
 	},
 	"mounts": [
         "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
-    ]
+    ],
+    "postCreateCommand": "bash .devcontainer/scripts/post_create.sh ${containerWorkspaceFolder}"
+
 }

--- a/.devcontainer/scripts/post_create.sh
+++ b/.devcontainer/scripts/post_create.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+working_dir=$1
+
+git config --global --add safe.directory $working_dir


### PR DESCRIPTION
This pull request adds a post create shell script to configure the devcontainer. The script sets the working directory and adds a safe directory configuration to the global git configuration.